### PR TITLE
Add dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "start": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
+    "dev": "tsc && concurrently -k -r \"tsc --watch\" \"wds\"",
     "build": "rimraf dist && tsc && node --max-old-space-size=4096 node_modules/rollup/dist/bin/rollup -c rollup.config.mjs",
     "start:build": "web-dev-server --root-dir dist --app-index index.html --open",
     "lint": "eslint \"**/*.{js,ts}\" --ignore-path .gitignore",


### PR DESCRIPTION
This PR adds a new "dev" script to package.json that mirrors the existing "start" script. This provides developers with an alternative command to start the development server.

The added script runs the same commands as the "start" script:
- Compiles TypeScript
- Concurrently runs TypeScript in watch mode and the web dev server

tag @builderio-bot for anything you want the bot to do

🔗 [Edit in Builder.io](https://builder.io/fiddle?branchName=zen-haven&projectId=df8a79632ba74c57a89d91c03c3cd10c)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>df8a79632ba74c57a89d91c03c3cd10c</projectId>-->